### PR TITLE
Remove the ^ arithmetic operator

### DIFF
--- a/content/en/guides/grasshopper/csharp-essentials/2-csharp-basics/index.md
+++ b/content/en/guides/grasshopper/csharp-essentials/2-csharp-basics/index.md
@@ -103,11 +103,6 @@ Operators are used to perform arithmetic, logical, and other operations. Operato
   </tr>
   <tr>
     <td>Arithmetic </n>Operators</td>
-    <td>^</td>
-    <td>Raises a number to the power of another number</td>
-  </tr>
-  <tr>
-    <td> </td>
     <td>*</td>
     <td>Multiplies two numbers</td>
   </tr>


### PR DESCRIPTION
^The ^operator stands for logical XOR rather than power operation in C#